### PR TITLE
feat(biometric): add macOS Touch ID support

### DIFF
--- a/.changes/biometric-macos-touch-id.md
+++ b/.changes/biometric-macos-touch-id.md
@@ -1,0 +1,6 @@
+---
+biometric: minor
+biometric-js: minor
+---
+
+Add macOS support: `checkStatus` and `authenticate` now work on macOS via the LocalAuthentication framework (Touch ID, optional Apple Watch approval via the new `allowWatch` option, and login-password fallback via `allowDeviceCredential`).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,7 +300,7 @@ dependencies = [
  "objc2-foundation 0.3.0",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -1041,7 +1041,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1862,7 +1862,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3999,6 +3999,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-local-authentication"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fc4c269ebb5210f5ae57ce061e08ec05cf35a6fb4a5d8287c7d4b1776ea6700"
+dependencies = [
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.0",
+]
+
+[[package]]
 name = "objc2-metal"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4720,7 +4731,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5170,7 +5181,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5183,7 +5194,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5240,7 +5251,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6472,7 +6483,11 @@ dependencies = [
 name = "tauri-plugin-biometric"
 version = "2.3.2"
 dependencies = [
+ "block2 0.6.2",
  "log",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.0",
+ "objc2-local-authentication",
  "serde",
  "serde_json",
  "serde_repr",
@@ -7055,7 +7070,7 @@ dependencies = [
  "getrandom 0.3.2",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8195,7 +8210,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/examples/api/src-tauri/Cargo.toml
+++ b/examples/api/src-tauri/Cargo.toml
@@ -37,6 +37,7 @@ tauri-plugin-os = { path = "../../../plugins/os", version = "2.3.2" }
 tauri-plugin-process = { path = "../../../plugins/process", version = "2.3.1" }
 tauri-plugin-opener = { path = "../../../plugins/opener", version = "2.5.4" }
 tauri-plugin-shell = { path = "../../../plugins/shell", version = "2.3.5" }
+tauri-plugin-biometric = { path = "../../../plugins/biometric/", version = "2.3.2" }
 tauri-plugin-store = { path = "../../../plugins/store", version = "2.4.3" }
 tauri-plugin-upload = { path = "../../../plugins/upload", version = "2.3.0" }
 
@@ -63,7 +64,6 @@ tauri-plugin-window-state = { path = "../../../plugins/window-state", version = 
 [target."cfg(any(target_os = \"android\", target_os = \"ios\"))".dependencies]
 tauri-plugin-barcode-scanner = { path = "../../../plugins/barcode-scanner/", version = "2.4.5" }
 tauri-plugin-nfc = { path = "../../../plugins/nfc", version = "2.3.5" }
-tauri-plugin-biometric = { path = "../../../plugins/biometric/", version = "2.3.2" }
 tauri-plugin-geolocation = { path = "../../../plugins/geolocation/", version = "2.3.2" }
 tauri-plugin-haptics = { path = "../../../plugins/haptics/", version = "2.3.2" }
 

--- a/examples/api/src-tauri/capabilities/desktop.json
+++ b/examples/api/src-tauri/capabilities/desktop.json
@@ -5,6 +5,7 @@
   "windows": ["main"],
   "platforms": ["linux", "macOS", "windows"],
   "permissions": [
+    "biometric:default",
     "cli:default",
     "updater:default",
     "global-shortcut:allow-unregister",

--- a/examples/api/src-tauri/capabilities/mobile.json
+++ b/examples/api/src-tauri/capabilities/mobile.json
@@ -7,7 +7,7 @@
   "permissions": [
     "nfc:allow-write",
     "nfc:allow-scan",
-    "biometric:allow-authenticate",
+    "biometric:default",
     "barcode-scanner:allow-scan",
     "barcode-scanner:allow-cancel",
     "barcode-scanner:allow-request-permissions",

--- a/examples/api/src-tauri/src/lib.rs
+++ b/examples/api/src-tauri/src/lib.rs
@@ -41,6 +41,7 @@ pub fn run() {
         .plugin(tauri_plugin_store::Builder::default().build())
         .plugin(tauri_plugin_upload::init())
         .setup(move |app| {
+            app.handle().plugin(tauri_plugin_biometric::init())?;
             #[cfg(desktop)]
             {
                 tray::create_tray(app.handle())?;
@@ -56,7 +57,6 @@ pub fn run() {
             {
                 app.handle().plugin(tauri_plugin_barcode_scanner::init())?;
                 app.handle().plugin(tauri_plugin_nfc::init())?;
-                app.handle().plugin(tauri_plugin_biometric::init())?;
                 app.handle().plugin(tauri_plugin_geolocation::init())?;
                 app.handle().plugin(tauri_plugin_haptics::init())?;
             }

--- a/examples/api/src/App.svelte
+++ b/examples/api/src/App.svelte
@@ -46,6 +46,8 @@
 
   const userAgent = navigator.userAgent.toLowerCase()
   const isMobile = userAgent.includes('android') || userAgent.includes('iphone')
+  // the desktop user agent is set to `Tauri API - <std::env::consts::OS>`
+  const isMacOS = !isMobile && userAgent.includes('macos')
 
   const views = [
     {
@@ -133,7 +135,7 @@
       component: Nfc,
       icon: 'i-ph-nfc'
     },
-    isMobile && {
+    (isMobile || isMacOS) && {
       label: 'Biometric',
       component: Biometric,
       icon: 'i-ph-scan'

--- a/examples/api/src/views/Biometric.svelte
+++ b/examples/api/src/views/Biometric.svelte
@@ -1,12 +1,18 @@
 <script>
-  import { authenticate } from "@tauri-apps/plugin-biometric";
+  import { authenticate, checkStatus } from "@tauri-apps/plugin-biometric";
 
   export let onMessage;
   let allowDeviceCredential = true;
+  let allowWatch = false;
+
+  function status() {
+    checkStatus().then(onMessage).catch(onMessage);
+  }
 
   function auth() {
     authenticate("Tauri API wants to show it is awesome :)", {
       allowDeviceCredential,
+      allowWatch,
       cancelTitle: "Cancel request",
       fallbackTitle: "Trying the fallback option",
       title: "Tauri API Auth",
@@ -22,9 +28,14 @@
 <div>
   <input
     type="checkbox"
-    id="dllowDeviceCredential"
+    id="allowDeviceCredential"
     bind:checked={allowDeviceCredential}
   />
-  <label for="allowDeviceCredentiale">Allow device credential</label>
+  <label for="allowDeviceCredential">Allow device credential</label>
 </div>
+<div>
+  <input type="checkbox" id="allowWatch" bind:checked={allowWatch} />
+  <label for="allowWatch">Allow Apple Watch (macOS)</label>
+</div>
+<button class="btn" id="check-status" on:click={status}> Check status </button>
 <button class="btn" id="cli-matches" on:click={auth}> Authenticate </button>

--- a/examples/api/src/views/Biometric.svelte
+++ b/examples/api/src/views/Biometric.svelte
@@ -20,7 +20,7 @@
       confirmationRequired: false,
       maxAttemps: 1,
     })
-      .then(onMessage)
+      .then(() => onMessage("Authenticated successfully"))
       .catch(onMessage);
   }
 </script>

--- a/plugins/biometric/Cargo.toml
+++ b/plugins/biometric/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tauri-plugin-biometric"
 version = "2.3.2"
-description = "Prompt the user for biometric authentication on Android and iOS."
+description = "Prompt the user for biometric authentication on Android, iOS and macOS."
 edition = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
@@ -9,12 +9,12 @@ repository = { workspace = true }
 links = "tauri-plugin-biometric"
 
 [package.metadata.docs.rs]
-targets = ["x86_64-linux-android"]
+targets = ["x86_64-linux-android", "aarch64-apple-darwin"]
 
 [package.metadata.platforms.support]
 windows = { level = "none", notes = "" }
 linux = { level = "none", notes = "" }
-macos = { level = "none", notes = "" }
+macos = { level = "full", notes = "Requires a Mac with Touch ID (built-in or Magic Keyboard); Apple Watch approval can be enabled via `allowWatch`" }
 android = { level = "full", notes = "" }
 ios = { level = "full", notes = "" }
 
@@ -29,3 +29,22 @@ tauri = { workspace = true }
 log = { workspace = true }
 thiserror = { workspace = true }
 serde_repr = "0.1"
+
+[target.'cfg(target_os = "ios")'.dependencies]
+tauri = { workspace = true, features = ["wry"] }
+
+[target."cfg(target_os = \"macos\")".dependencies]
+objc2 = "0.6"
+block2 = "0.6"
+objc2-foundation = { version = "0.3", default-features = false, features = [
+  "std",
+  "NSString",
+  "NSError",
+] }
+objc2-local-authentication = { version = "0.3", default-features = false, features = [
+  "std",
+  "LAContext",
+  "LAError",
+  "LABiometryType",
+  "block2",
+] }

--- a/plugins/biometric/README.md
+++ b/plugins/biometric/README.md
@@ -1,14 +1,16 @@
 ![biometric](https://github.com/tauri-apps/plugins-workspace/raw/v2/plugins/biometric/banner.png)
 
-Prompt the user for biometric authentication on Android and iOS.
+Prompt the user for biometric authentication on Android, iOS and macOS.
 
 | Platform | Supported |
 | -------- | --------- |
 | Linux    | x         |
 | Windows  | x         |
-| macOS    | x         |
+| macOS    | ✓         |
 | Android  | ✓         |
 | iOS      | ✓         |
+
+On macOS, authentication uses Touch ID (built-in or via a Magic Keyboard with Touch ID). The `allowDeviceCredential` option falls back to the user's login password, and the `allowWatch` option additionally accepts approval from a paired Apple Watch.
 
 ## Install
 

--- a/plugins/biometric/README.md
+++ b/plugins/biometric/README.md
@@ -10,7 +10,7 @@ Prompt the user for biometric authentication on Android, iOS and macOS.
 | Android  | ✓         |
 | iOS      | ✓         |
 
-On macOS, authentication uses Touch ID (built-in or via a Magic Keyboard with Touch ID). The `allowDeviceCredential` option falls back to the user's login password, and the `allowWatch` option additionally accepts approval from a paired Apple Watch.
+On macOS, authentication uses Touch ID (built-in or via a Magic Keyboard with Touch ID). The `allowDeviceCredential` option falls back to the user's login password, and the `allowWatch` option additionally accepts approval from a paired Apple Watch — this requires the "Use Apple Watch to unlock your applications and your Mac" option to be enabled in System Settings > Touch ID & Password.
 
 ## Install
 

--- a/plugins/biometric/README.md
+++ b/plugins/biometric/README.md
@@ -10,7 +10,7 @@ Prompt the user for biometric authentication on Android, iOS and macOS.
 | Android  | ✓         |
 | iOS      | ✓         |
 
-On macOS, authentication uses Touch ID (built-in or via a Magic Keyboard with Touch ID). The `allowDeviceCredential` option falls back to the user's login password, and the `allowWatch` option additionally accepts approval from a paired Apple Watch — this requires the "Use Apple Watch to unlock your applications and your Mac" option to be enabled in System Settings > Touch ID & Password.
+On macOS, authentication uses Touch ID (built-in or via a Magic Keyboard with Touch ID). The `allowDeviceCredential` option falls back to the user's login password, and the `allowWatch` option additionally accepts approval from a paired Apple Watch — this requires the "Use Apple Watch to unlock your applications and your Mac" option to be enabled in System Settings > Touch ID & Password. Note that `allowDeviceCredential` always accepts Apple Watch approval as well, regardless of `allowWatch`: macOS provides no policy that combines the password fallback with biometrics but excludes the watch.
 
 ## Install
 

--- a/plugins/biometric/guest-js/index.ts
+++ b/plugins/biometric/guest-js/index.ts
@@ -41,7 +41,12 @@ export interface AuthOptions {
   fallbackTitle?: string
 
   // macOS options
-  /** Allows authenticating by approving on a nearby, paired and unlocked Apple Watch. */
+  /**
+   * Allows authenticating by approving on a nearby, paired and unlocked Apple Watch.
+   *
+   * Requires the "Apple Watch" option to be enabled in
+   * System Settings > Touch ID & Password ("Use Apple Watch to unlock your applications and your Mac").
+   */
   allowWatch?: boolean
 
   // android options

--- a/plugins/biometric/guest-js/index.ts
+++ b/plugins/biometric/guest-js/index.ts
@@ -46,6 +46,10 @@ export interface AuthOptions {
    *
    * Requires the "Apple Watch" option to be enabled in
    * System Settings > Touch ID & Password ("Use Apple Watch to unlock your applications and your Mac").
+   *
+   * Note that when `allowDeviceCredential` is `true`, macOS always accepts Apple Watch
+   * approval regardless of this option — the system provides no policy that combines
+   * the password fallback with biometrics but excludes the watch.
    */
   allowWatch?: boolean
 

--- a/plugins/biometric/guest-js/index.ts
+++ b/plugins/biometric/guest-js/index.ts
@@ -30,14 +30,19 @@ export interface Status {
     | 'biometryLockout'
     | 'biometryNotAvailable'
     | 'biometryNotEnrolled'
+    | 'watchNotAvailable'
 }
 
 export interface AuthOptions {
   allowDeviceCredential?: boolean
   cancelTitle?: string
 
-  // iOS options
+  // iOS and macOS options
   fallbackTitle?: string
+
+  // macOS options
+  /** Allows authenticating by approving on a nearby, paired and unlocked Apple Watch. */
+  allowWatch?: boolean
 
   // android options
   title?: string
@@ -55,7 +60,7 @@ export async function checkStatus(): Promise<Status> {
 }
 
 /**
- * Prompts the user for authentication using the system interface (touchID, faceID or Android Iris).
+ * Prompts the user for authentication using the system interface (touchID, faceID, Android Iris or macOS Touch ID).
  * Rejects if the authentication fails.
  *
  * ```javascript

--- a/plugins/biometric/src/commands.rs
+++ b/plugins/biometric/src/commands.rs
@@ -1,0 +1,46 @@
+// Copyright 2019-2023 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+use tauri::{command, AppHandle, Runtime};
+
+use crate::{AuthOptions, BiometricExt, Result, Status};
+
+#[command]
+pub(crate) async fn status<R: Runtime>(app: AppHandle<R>) -> Result<Status> {
+    app.biometric().status()
+}
+
+// the JS API sends the options flattened alongside `reason`,
+// so they are received as individual arguments here
+#[command]
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn authenticate<R: Runtime>(
+    app: AppHandle<R>,
+    reason: String,
+    allow_device_credential: Option<bool>,
+    cancel_title: Option<String>,
+    fallback_title: Option<String>,
+    title: Option<String>,
+    subtitle: Option<String>,
+    confirmation_required: Option<bool>,
+    allow_watch: Option<bool>,
+) -> Result<()> {
+    let options = AuthOptions {
+        allow_device_credential: allow_device_credential.unwrap_or(false),
+        cancel_title,
+        fallback_title,
+        title,
+        subtitle,
+        confirmation_required,
+        allow_watch,
+    };
+    // authenticate() blocks until the user completes or dismisses the
+    // system prompt, so it must run off the main thread
+    tauri::async_runtime::spawn_blocking(move || app.biometric().authenticate(reason, options))
+        .await
+        .map_err(|e| crate::Error::Authentication {
+            code: "authenticationFailed".into(),
+            message: e.to_string(),
+        })?
+}

--- a/plugins/biometric/src/desktop.rs
+++ b/plugins/biometric/src/desktop.rs
@@ -1,0 +1,193 @@
+// Copyright 2019-2023 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+use serde::de::DeserializeOwned;
+use tauri::{plugin::PluginApi, AppHandle, Runtime};
+
+use crate::models::*;
+
+pub fn init<R: Runtime, C: DeserializeOwned>(
+    app: &AppHandle<R>,
+    _api: PluginApi<R, C>,
+) -> crate::Result<Biometric<R>> {
+    Ok(Biometric(app.clone()))
+}
+
+/// Access to the biometric APIs.
+pub struct Biometric<R: Runtime>(AppHandle<R>);
+
+impl<R: Runtime> Biometric<R> {
+    pub fn status(&self) -> crate::Result<Status> {
+        #[cfg(target_os = "macos")]
+        return Ok(macos::status());
+        #[cfg(not(target_os = "macos"))]
+        Ok(Status {
+            is_available: false,
+            biometry_type: BiometryType::None,
+            error: Some("Biometric authentication is not available on this platform".into()),
+            error_code: Some("biometryNotAvailable".into()),
+        })
+    }
+
+    /// Prompts the user for authentication.
+    ///
+    /// Blocks until the user completes or dismisses the system prompt,
+    /// so it must not be called on the main thread.
+    pub fn authenticate(&self, reason: String, options: AuthOptions) -> crate::Result<()> {
+        #[cfg(target_os = "macos")]
+        return macos::authenticate(&reason, &options);
+        #[cfg(not(target_os = "macos"))]
+        {
+            let _ = (reason, options);
+            Err(crate::Error::Authentication {
+                code: "biometryNotAvailable".into(),
+                message: "Biometric authentication is not available on this platform".into(),
+            })
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use block2::RcBlock;
+    use objc2::runtime::Bool;
+    use objc2_foundation::{NSError, NSString};
+    use objc2_local_authentication::{LABiometryType, LAContext, LAError, LAPolicy};
+
+    use crate::models::*;
+
+    // matches the error code strings of the iOS implementation
+    fn error_code(code: isize) -> &'static str {
+        let error = LAError(code);
+        if error == LAError::AppCancel {
+            "appCancel"
+        } else if error == LAError::AuthenticationFailed {
+            "authenticationFailed"
+        } else if error == LAError::InvalidContext {
+            "invalidContext"
+        } else if error == LAError::NotInteractive {
+            "notInteractive"
+        } else if error == LAError::PasscodeNotSet {
+            "passcodeNotSet"
+        } else if error == LAError::SystemCancel {
+            "systemCancel"
+        } else if error == LAError::UserCancel {
+            "userCancel"
+        } else if error == LAError::UserFallback {
+            "userFallback"
+        } else if error == LAError::BiometryLockout {
+            "biometryLockout"
+        } else if error == LAError::BiometryNotAvailable {
+            "biometryNotAvailable"
+        } else if error == LAError::BiometryNotEnrolled {
+            "biometryNotEnrolled"
+        } else if error == LAError::CompanionNotAvailable {
+            // LAErrorWatchNotAvailable before the Companion rename
+            "watchNotAvailable"
+        } else {
+            "authenticationFailed"
+        }
+    }
+
+    fn check_policy(context: &LAContext, policy: LAPolicy) -> Result<(), (String, String)> {
+        unsafe { context.canEvaluatePolicy_error(policy) }.map_err(|e| {
+            (
+                e.localizedDescription().to_string(),
+                error_code(e.code()).to_string(),
+            )
+        })
+    }
+
+    pub fn status() -> Status {
+        let context = unsafe { LAContext::new() };
+        let result = check_policy(&context, LAPolicy::DeviceOwnerAuthenticationWithBiometrics);
+        // biometryType is only valid after canEvaluatePolicy was called
+        let biometry_type = match unsafe { context.biometryType() } {
+            LABiometryType::TouchID => BiometryType::TouchID,
+            LABiometryType::FaceID => BiometryType::FaceID,
+            _ => BiometryType::None,
+        };
+        match result {
+            Ok(()) => Status {
+                is_available: true,
+                biometry_type,
+                error: None,
+                error_code: None,
+            },
+            Err((error, error_code)) => Status {
+                is_available: false,
+                biometry_type,
+                error: Some(error),
+                error_code: Some(error_code),
+            },
+        }
+    }
+
+    pub fn authenticate(reason: &str, options: &AuthOptions) -> crate::Result<()> {
+        let policy = if options.allow_device_credential {
+            // also covers Touch ID, Apple Watch and the login password
+            LAPolicy::DeviceOwnerAuthentication
+        } else if options.allow_watch == Some(true) {
+            // LAPolicyDeviceOwnerAuthenticationWithBiometricsOrWatch before the Companion rename
+            LAPolicy::DeviceOwnerAuthenticationWithBiometricsOrCompanion
+        } else {
+            LAPolicy::DeviceOwnerAuthenticationWithBiometrics
+        };
+
+        let context = unsafe { LAContext::new() };
+        if let Err((message, code)) = check_policy(&context, policy) {
+            return Err(crate::Error::Authentication { code, message });
+        }
+
+        let cancel_title = options.cancel_title.as_deref().map(NSString::from_str);
+        // parity with the iOS implementation: an empty fallback title with
+        // device credentials allowed shows the default fallback button
+        let fallback_title = match (&options.fallback_title, options.allow_device_credential) {
+            (Some(title), true) if title.is_empty() => None,
+            (title, _) => title.as_deref().map(NSString::from_str),
+        };
+        unsafe {
+            context.setTouchIDAuthenticationAllowableReuseDuration(0.0);
+            context.setLocalizedCancelTitle(cancel_title.as_deref());
+            context.setLocalizedFallbackTitle(fallback_title.as_deref());
+        }
+
+        let (tx, rx) = std::sync::mpsc::channel::<Result<(), (String, String)>>();
+        let reply = RcBlock::new(move |success: Bool, error: *mut NSError| {
+            let result = if success.as_bool() {
+                Ok(())
+            } else if let Some(error) = unsafe { error.as_ref() } {
+                Err((
+                    error.localizedDescription().to_string(),
+                    error_code(error.code()).to_string(),
+                ))
+            } else {
+                Err((
+                    "Unknown authentication error".to_string(),
+                    "authenticationFailed".to_string(),
+                ))
+            };
+            let _ = tx.send(result);
+        });
+
+        unsafe {
+            context.evaluatePolicy_localizedReason_reply(
+                policy,
+                &NSString::from_str(reason),
+                &reply,
+            );
+        }
+
+        // `context` must be kept alive until the reply block runs,
+        // otherwise the evaluation is canceled
+        match rx.recv() {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err((message, code))) => Err(crate::Error::Authentication { code, message }),
+            Err(_) => Err(crate::Error::Authentication {
+                code: "authenticationFailed".into(),
+                message: "Authentication reply channel closed".into(),
+            }),
+        }
+    }
+}

--- a/plugins/biometric/src/error.rs
+++ b/plugins/biometric/src/error.rs
@@ -13,6 +13,12 @@ pub enum Error {
     #[cfg(mobile)]
     #[error(transparent)]
     PluginInvoke(#[from] tauri::plugin::mobile::PluginInvokeError),
+    /// Authentication failed or is unavailable.
+    ///
+    /// `code` matches the error code strings used by the mobile implementations
+    /// (e.g. `userCancel`, `biometryNotAvailable`).
+    #[error("{message}")]
+    Authentication { code: String, message: String },
 }
 
 impl Serialize for Error {
@@ -20,6 +26,17 @@ impl Serialize for Error {
     where
         S: Serializer,
     {
-        serializer.serialize_str(self.to_string().as_ref())
+        match self {
+            // matches the `{ message, code }` rejection shape produced by
+            // the mobile implementations via `invoke.reject(message, code:)`
+            Self::Authentication { code, message } => {
+                use serde::ser::SerializeStruct;
+                let mut s = serializer.serialize_struct("Error", 2)?;
+                s.serialize_field("message", message)?;
+                s.serialize_field("code", code)?;
+                s.end()
+            }
+            _ => serializer.serialize_str(self.to_string().as_ref()),
+        }
     }
 }

--- a/plugins/biometric/src/lib.rs
+++ b/plugins/biometric/src/lib.rs
@@ -2,48 +2,28 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-#![cfg(mobile)]
-
-use serde::Serialize;
 use tauri::{
-    plugin::{Builder, PluginHandle, TauriPlugin},
+    plugin::{Builder, TauriPlugin},
     Manager, Runtime,
 };
 
 pub use models::*;
 
+#[cfg(desktop)]
+mod commands;
+#[cfg(desktop)]
+mod desktop;
 mod error;
+#[cfg(mobile)]
+mod mobile;
 mod models;
 
 pub use error::{Error, Result};
 
-#[cfg(target_os = "android")]
-const PLUGIN_IDENTIFIER: &str = "app.tauri.biometric";
-
-#[cfg(target_os = "ios")]
-tauri::ios_plugin_binding!(init_plugin_biometric);
-
-/// Access to the biometric APIs.
-pub struct Biometric<R: Runtime>(PluginHandle<R>);
-
-#[derive(Serialize)]
-struct AuthenticatePayload {
-    reason: String,
-    #[serde(flatten)]
-    options: AuthOptions,
-}
-
-impl<R: Runtime> Biometric<R> {
-    pub fn status(&self) -> crate::Result<Status> {
-        self.0.run_mobile_plugin("status", ()).map_err(Into::into)
-    }
-
-    pub fn authenticate(&self, reason: String, options: AuthOptions) -> crate::Result<()> {
-        self.0
-            .run_mobile_plugin("authenticate", AuthenticatePayload { reason, options })
-            .map_err(Into::into)
-    }
-}
+#[cfg(desktop)]
+pub use desktop::Biometric;
+#[cfg(mobile)]
+pub use mobile::Biometric;
 
 /// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::WebviewWindow`], [`tauri::Webview`] and [`tauri::Window`] to access the biometric APIs.
 pub trait BiometricExt<R: Runtime> {
@@ -58,13 +38,22 @@ impl<R: Runtime, T: Manager<R>> crate::BiometricExt<R> for T {
 
 /// Initializes the plugin.
 pub fn init<R: Runtime>() -> TauriPlugin<R> {
-    Builder::new("biometric")
+    let builder = Builder::new("biometric");
+    // the invoke handler must only be registered on desktop: on mobile,
+    // commands handled in Rust never reach the native Swift/Kotlin plugin,
+    // which implements `status` and `authenticate` itself
+    #[cfg(desktop)]
+    let builder = builder.invoke_handler(tauri::generate_handler![
+        commands::status,
+        commands::authenticate
+    ]);
+    builder
         .setup(|app, api| {
-            #[cfg(target_os = "android")]
-            let handle = api.register_android_plugin(PLUGIN_IDENTIFIER, "BiometricPlugin")?;
-            #[cfg(target_os = "ios")]
-            let handle = api.register_ios_plugin(init_plugin_biometric)?;
-            app.manage(Biometric(handle));
+            #[cfg(mobile)]
+            let biometric = mobile::init(app, api)?;
+            #[cfg(desktop)]
+            let biometric = desktop::init(app, api)?;
+            app.manage(biometric);
             Ok(())
         })
         .build()

--- a/plugins/biometric/src/mobile.rs
+++ b/plugins/biometric/src/mobile.rs
@@ -1,0 +1,50 @@
+// Copyright 2019-2023 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+use serde::{de::DeserializeOwned, Serialize};
+use tauri::{
+    plugin::{PluginApi, PluginHandle},
+    AppHandle, Runtime,
+};
+
+use crate::models::*;
+
+#[cfg(target_os = "android")]
+const PLUGIN_IDENTIFIER: &str = "app.tauri.biometric";
+
+#[cfg(target_os = "ios")]
+tauri::ios_plugin_binding!(init_plugin_biometric);
+
+pub fn init<R: Runtime, C: DeserializeOwned>(
+    _app: &AppHandle<R>,
+    api: PluginApi<R, C>,
+) -> crate::Result<Biometric<R>> {
+    #[cfg(target_os = "android")]
+    let handle = api.register_android_plugin(PLUGIN_IDENTIFIER, "BiometricPlugin")?;
+    #[cfg(target_os = "ios")]
+    let handle = api.register_ios_plugin(init_plugin_biometric)?;
+    Ok(Biometric(handle))
+}
+
+/// Access to the biometric APIs.
+pub struct Biometric<R: Runtime>(PluginHandle<R>);
+
+#[derive(Serialize)]
+struct AuthenticatePayload {
+    reason: String,
+    #[serde(flatten)]
+    options: AuthOptions,
+}
+
+impl<R: Runtime> Biometric<R> {
+    pub fn status(&self) -> crate::Result<Status> {
+        self.0.run_mobile_plugin("status", ()).map_err(Into::into)
+    }
+
+    pub fn authenticate(&self, reason: String, options: AuthOptions) -> crate::Result<()> {
+        self.0
+            .run_mobile_plugin("authenticate", AuthenticatePayload { reason, options })
+            .map_err(Into::into)
+    }
+}

--- a/plugins/biometric/src/models.rs
+++ b/plugins/biometric/src/models.rs
@@ -20,6 +20,9 @@ pub struct AuthOptions {
     /// Specifies whether additional user confirmation is required, such as pressing a button after successful biometric authentication. This feature is available Android only.
     pub confirmation_required: Option<bool>,
     /// Allows the user to authenticate by approving on a nearby, paired and unlocked Apple Watch. This feature is available macOS only.
+    ///
+    /// Requires the "Apple Watch" option to be enabled in System Settings > Touch ID & Password
+    /// ("Use Apple Watch to unlock your applications and your Mac").
     pub allow_watch: Option<bool>,
 }
 

--- a/plugins/biometric/src/models.rs
+++ b/plugins/biometric/src/models.rs
@@ -7,11 +7,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AuthOptions {
-    /// Enables authentication using the device's password. This feature is available on both Android and iOS.
+    /// Enables authentication using the device's password. This feature is available on Android, iOS and macOS.
     pub allow_device_credential: bool,
-    /// Label for the Cancel button. This feature is available on both Android and iOS.
+    /// Label for the Cancel button. This feature is available on Android, iOS and macOS.
     pub cancel_title: Option<String>,
-    /// Specifies the text displayed on the fallback button if biometric authentication fails. This feature is available iOS only.
+    /// Specifies the text displayed on the fallback button if biometric authentication fails. This feature is available on iOS and macOS.
     pub fallback_title: Option<String>,
     /// Title indicating the purpose of biometric verification. This feature is available Android only.
     pub title: Option<String>,
@@ -19,9 +19,11 @@ pub struct AuthOptions {
     pub subtitle: Option<String>,
     /// Specifies whether additional user confirmation is required, such as pressing a button after successful biometric authentication. This feature is available Android only.
     pub confirmation_required: Option<bool>,
+    /// Allows the user to authenticate by approving on a nearby, paired and unlocked Apple Watch. This feature is available macOS only.
+    pub allow_watch: Option<bool>,
 }
 
-#[derive(Debug, Clone, serde_repr::Deserialize_repr)]
+#[derive(Debug, Clone, serde_repr::Serialize_repr, serde_repr::Deserialize_repr)]
 #[repr(u8)]
 pub enum BiometryType {
     None = 0,
@@ -29,11 +31,13 @@ pub enum BiometryType {
     FaceID = 2,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Status {
     pub is_available: bool,
     pub biometry_type: BiometryType,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub error_code: Option<String>,
 }

--- a/plugins/biometric/src/models.rs
+++ b/plugins/biometric/src/models.rs
@@ -23,6 +23,10 @@ pub struct AuthOptions {
     ///
     /// Requires the "Apple Watch" option to be enabled in System Settings > Touch ID & Password
     /// ("Use Apple Watch to unlock your applications and your Mac").
+    ///
+    /// Note that when `allow_device_credential` is `true`, macOS always accepts Apple Watch
+    /// approval regardless of this option — the system provides no policy that combines
+    /// the password fallback with biometrics but excludes the watch.
     pub allow_watch: Option<bool>,
 }
 


### PR DESCRIPTION
## What

Adds macOS support to `tauri-plugin-biometric`: `checkStatus` and `authenticate` now work on macOS using the LocalAuthentication framework (pure Rust via `objc2-local-authentication`, no Swift bridge).

- **Touch ID** authentication (built-in or Magic Keyboard with Touch ID)
- `allowDeviceCredential` falls back to the user's **login password** (`LAPolicy::DeviceOwnerAuthentication`)
- New opt-in `allowWatch` option accepts approval from a paired **Apple Watch** (`LAPolicy::DeviceOwnerAuthenticationWithBiometricsOrCompanion`)
- Error codes match the iOS implementation 1:1 (`userCancel`, `biometryNotEnrolled`, …) plus `watchNotAvailable`; rejections carry the same `{ message, code }` shape as mobile's `invoke.reject(message, code:)`
- Windows/Linux now compile and gracefully report `biometryNotAvailable`

## How

- Restructured into the workspace's `desktop.rs`/`mobile.rs` pattern (mirrors `plugins/haptics`); `mobile.rs` is a pure relocation of the existing code
- **The Rust `invoke_handler` is registered on desktop only** — on mobile, tauri only falls through to the native Swift/Kotlin plugin when the Rust handler does NOT handle a command, so registering it there would shadow the native `status`/`authenticate`. Mobile wire behavior is unchanged
- `authenticate` blocks on the LAContext reply block via `spawn_blocking` + mpsc channel; the `Retained<LAContext>` is kept alive until the reply fires
- `biometryType` is read after `canEvaluatePolicy` (required for validity); `touchIDAuthenticationAllowableReuseDuration = 0` matches iOS
- examples/api: Biometric view now shows on macOS with a status button and Watch toggle

## Verification

- `cargo check` / `clippy --all-targets -- -D warnings` / `fmt --check` on macOS host: clean
- `cargo check --target aarch64-apple-ios`: clean (required adding the same `tauri/wry` iOS target dep haptics uses)
- `cargo check -p api` (example app): clean
- `pnpm --filter @tauri-apps/plugin-biometric build`: clean (type-only JS changes; `api-iife.js` unchanged)
- Manual Touch ID testing on hardware: **pending** (to be done before upstreaming)

## Notes for review

- `Status`/`BiometryType` gained `Serialize` derives and `AuthOptions` a new optional field — all additive, mobile deserialization unaffected; Swift/Kotlin decoders ignore the unknown `allowWatch` key
- Pre-existing gap noticed but not addressed here: Rust `BiometryType` lacks `Iris = 3` which Android can emit (only affects Rust-side `status()` consumers)
- No Info.plist/entitlement requirements: `NSFaceIDUsageDescription` is iOS/Face ID-only and plain `LAContext.evaluatePolicy` works sandboxed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds macOS Touch ID support to `tauri-plugin-biometric`. `checkStatus` and `authenticate` now work on macOS via LocalAuthentication, with optional Apple Watch approval and login‑password fallback; on macOS `allowDeviceCredential` also accepts Apple Watch. Error codes match iOS.

- **New Features**
  - macOS implementation in pure Rust (`objc2-local-authentication`).
  - `allowWatch` for Apple Watch; `allowDeviceCredential` falls back to the login password and always includes Apple Watch on macOS.
  - Errors match iOS (`userCancel`, `biometryNotEnrolled`, …) plus `watchNotAvailable`; Windows/Linux return `biometryNotAvailable`.
  - Plugin split into `desktop.rs` and `mobile.rs`; Rust invoke handler registered on desktop only.
  - JS API (`@tauri-apps/plugin-biometric`) adds `allowWatch` and `watchNotAvailable`.

- **Dependencies**
  - Add `objc2`, `objc2-foundation`, `objc2-local-authentication`, and `block2` to `tauri-plugin-biometric`.
  - Bump `windows-sys` across the workspace.

<sup>Written for commit 031d3fb5edb74f793f5f27ca441a157aa252931e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sosweetham/plugins-workspace/pull/2?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

